### PR TITLE
Refactor landing page and create utils, interfaces, and constants

### DIFF
--- a/web/app/topics/[name]/page.tsx
+++ b/web/app/topics/[name]/page.tsx
@@ -1,7 +1,12 @@
 import Link from "next/link";
 
 import { LocalDateTime } from "@/components/local-date-time";
-import { EmptyState, ErrorState, PageFrame, StatCard } from "@/components/page-frame";
+import {
+  EmptyState,
+  ErrorState,
+  PageFrame,
+  StatCard,
+} from "@/components/page-frame";
 import { TopicBrowseForm } from "@/components/topic-browse-form";
 import { TopicMessagesTable } from "@/components/topic-messages-table";
 import { getTopic, getTopicMessages } from "@/lib/api";
@@ -9,10 +14,10 @@ import { getTopic, getTopicMessages } from "@/lib/api";
 export const dynamic = "force-dynamic";
 
 type TopicDetailPageProps = {
-  params: Promise<{
+  readonly params: Promise<{
     name: string;
   }>;
-  searchParams?: Promise<{
+  readonly searchParams?: Promise<{
     partition?: string;
     position?: string;
     offset?: string;
@@ -23,7 +28,7 @@ type TopicDetailPageProps = {
 
 export default async function TopicDetailPage({
   params,
-  searchParams
+  searchParams,
 }: TopicDetailPageProps) {
   const { name } = await params;
   const query = (await searchParams) ?? {};
@@ -32,7 +37,7 @@ export default async function TopicDetailPage({
     .then((topic) => ({ topic, error: null as string | null }))
     .catch((error: unknown) => ({
       topic: null,
-      error: error instanceof Error ? error.message : "Unknown error"
+      error: error instanceof Error ? error.message : "Unknown error",
     }));
 
   if (result.error || !result.topic) {
@@ -66,15 +71,17 @@ export default async function TopicDetailPage({
       : await getTopicMessages(topic.name, {
           partition: selectedPartition,
           position:
-            selectedOffset === null && selectedTimestamp === null ? selectedPosition : undefined,
+            selectedOffset === null && selectedTimestamp === null
+              ? selectedPosition
+              : undefined,
           offset: selectedOffset ?? undefined,
           timestamp: selectedTimestamp ?? undefined,
-          limit: selectedLimit
+          limit: selectedLimit,
         })
           .then((messages) => ({ messages, error: null as string | null }))
           .catch((error: unknown) => ({
             messages: null,
-            error: error instanceof Error ? error.message : "Unknown error"
+            error: error instanceof Error ? error.message : "Unknown error",
           }));
 
   return (
@@ -96,7 +103,9 @@ export default async function TopicDetailPage({
         />
         <StatCard
           label="Leaders"
-          value={String(new Set(topic.partitions.map((partition) => partition.leader)).size)}
+          value={String(
+            new Set(topic.partitions.map((partition) => partition.leader)).size,
+          )}
           hint="Distinct broker leaders for this topic."
         />
       </div>
@@ -110,14 +119,20 @@ export default async function TopicDetailPage({
         <div className="space-y-6">
           <div
             className="overflow-hidden rounded-[28px] border"
-            style={{ borderColor: "var(--surface-border)", background: "var(--surface-1)" }}
+            style={{
+              borderColor: "var(--surface-border)",
+              background: "var(--surface-1)",
+            }}
           >
             <div className="overflow-x-auto">
               <table className="min-w-full border-collapse">
                 <thead>
                   <tr
                     className="border-b text-left text-[11px] uppercase tracking-[0.24em]"
-                    style={{ borderColor: "var(--surface-border)", color: "var(--text-muted)" }}
+                    style={{
+                      borderColor: "var(--surface-border)",
+                      color: "var(--text-muted)",
+                    }}
                   >
                     <th className="px-5 py-4 font-semibold">Partition</th>
                     <th className="px-5 py-4 font-semibold">Leader</th>
@@ -131,14 +146,21 @@ export default async function TopicDetailPage({
                       key={partition.id}
                       className="border-t text-sm"
                       style={{
-                        borderColor: "color-mix(in srgb, var(--surface-border) 50%, transparent)",
-                        color: "var(--text-secondary)"
+                        borderColor:
+                          "color-mix(in srgb, var(--surface-border) 50%, transparent)",
+                        color: "var(--text-secondary)",
                       }}
                     >
                       <td className="px-5 py-4 font-mono">{partition.id}</td>
-                      <td className="px-5 py-4 font-mono">{partition.leader}</td>
-                      <td className="px-5 py-4 font-mono">{partition.replicas.join(", ")}</td>
-                      <td className="px-5 py-4 font-mono">{partition.isr.join(", ")}</td>
+                      <td className="px-5 py-4 font-mono">
+                        {partition.leader}
+                      </td>
+                      <td className="px-5 py-4 font-mono">
+                        {partition.replicas.join(", ")}
+                      </td>
+                      <td className="px-5 py-4 font-mono">
+                        {partition.isr.join(", ")}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -148,21 +170,34 @@ export default async function TopicDetailPage({
 
           <div
             className="rounded-[28px] border p-5"
-            style={{ borderColor: "var(--surface-border)", background: "var(--surface-1)" }}
+            style={{
+              borderColor: "var(--surface-border)",
+              background: "var(--surface-1)",
+            }}
           >
             <div>
-              <h3 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+              <h3
+                className="text-lg font-semibold"
+                style={{ color: "var(--text-primary)" }}
+              >
                 Browse Messages
               </h3>
-              <p className="mt-2 max-w-3xl text-sm leading-6" style={{ color: "var(--text-muted)" }}>
-                Read a bounded slice of records for one partition without joining a consumer
-                group. Use latest for recent activity, offset for exact navigation, and timestamp
-                to jump to the first record at or after a chosen moment.
+              <p
+                className="mt-2 max-w-3xl text-sm leading-6"
+                style={{ color: "var(--text-muted)" }}
+              >
+                Read a bounded slice of records for one partition without
+                joining a consumer group. Use latest for recent activity, offset
+                for exact navigation, and timestamp to jump to the first record
+                at or after a chosen moment.
               </p>
             </div>
             <div
               className="mt-5 rounded-[24px] border p-4"
-              style={{ borderColor: "var(--surface-border)", background: "var(--surface-2)" }}
+              style={{
+                borderColor: "var(--surface-border)",
+                background: "var(--surface-2)",
+              }}
             >
               <TopicBrowseForm
                 key={`${selectedPartition}:${selectedPosition}:${selectedOffset ?? "none"}:${selectedTimestamp ?? "none"}:${selectedLimit}`}
@@ -178,7 +213,10 @@ export default async function TopicDetailPage({
 
             {browseResult.error ? (
               <div className="mt-5">
-                <ErrorState title="Failed to load topic messages" copy={browseResult.error} />
+                <ErrorState
+                  title="Failed to load topic messages"
+                  copy={browseResult.error}
+                />
               </div>
             ) : browseResult.messages ? (
               <div className="mt-5 space-y-4">
@@ -210,26 +248,46 @@ export default async function TopicDetailPage({
                   style={{
                     borderColor: "var(--surface-border)",
                     background: "var(--surface-2)",
-                    color: "var(--text-secondary)"
+                    color: "var(--text-secondary)",
                   }}
                 >
-                  <span className="font-semibold" style={{ color: "var(--text-primary)" }}>
+                  <span
+                    className="font-semibold"
+                    style={{ color: "var(--text-primary)" }}
+                  >
                     Browse Mode:
                   </span>{" "}
-                  <span className="capitalize">{browseResult.messages.request.mode}</span>
+                  <span className="capitalize">
+                    {browseResult.messages.request.mode}
+                  </span>
                   {typeof browseResult.messages.request.offset === "number" ? (
-                    <span className="ml-4" style={{ color: "var(--text-muted)" }}>
+                    <span
+                      className="ml-4"
+                      style={{ color: "var(--text-muted)" }}
+                    >
                       Requested offset{" "}
-                      <span className="font-mono" style={{ color: "var(--text-secondary)" }}>
+                      <span
+                        className="font-mono"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
                         {browseResult.messages.request.offset}
                       </span>
                     </span>
                   ) : null}
-                  {typeof browseResult.messages.request.timestamp === "number" ? (
-                    <span className="ml-4" style={{ color: "var(--text-muted)" }}>
+                  {typeof browseResult.messages.request.timestamp ===
+                  "number" ? (
+                    <span
+                      className="ml-4"
+                      style={{ color: "var(--text-muted)" }}
+                    >
                       Requested time{" "}
-                      <span className="font-mono" style={{ color: "var(--text-secondary)" }}>
-                        <LocalDateTime value={browseResult.messages.request.timestamp} />
+                      <span
+                        className="font-mono"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
+                        <LocalDateTime
+                          value={browseResult.messages.request.timestamp}
+                        />
                       </span>
                     </span>
                   ) : null}
@@ -240,13 +298,13 @@ export default async function TopicDetailPage({
                     href={buildBrowseHref(baseTopicPath, {
                       partition: browseResult.messages.partition,
                       position: "earliest",
-                      limit: browseResult.messages.request.limit
+                      limit: browseResult.messages.request.limit,
                     })}
                     className="rounded-2xl border px-4 py-2 text-sm font-semibold transition"
                     style={{
                       borderColor: "var(--surface-border)",
                       background: "var(--surface-2)",
-                      color: "var(--text-primary)"
+                      color: "var(--text-primary)",
                     }}
                   >
                     Restart From Earliest
@@ -255,19 +313,23 @@ export default async function TopicDetailPage({
                     href={buildBrowseHref(baseTopicPath, {
                       partition: browseResult.messages.partition,
                       offset: browseResult.messages.nextOffset,
-                      limit: browseResult.messages.request.limit
+                      limit: browseResult.messages.request.limit,
                     })}
                     className="rounded-2xl border px-4 py-2 text-sm font-semibold transition"
                     style={{
                       borderColor: "var(--accent-border)",
                       background: "var(--accent-soft)",
-                      color: "var(--accent-contrast)"
+                      color: "var(--accent-contrast)",
                     }}
                   >
                     Load Next {browseResult.messages.request.limit}
                   </Link>
-                  <p className="text-xs uppercase tracking-[0.18em]" style={{ color: "var(--text-muted)" }}>
-                    Next page starts at offset {browseResult.messages.nextOffset}
+                  <p
+                    className="text-xs uppercase tracking-[0.18em]"
+                    style={{ color: "var(--text-muted)" }}
+                  >
+                    Next page starts at offset{" "}
+                    {browseResult.messages.nextOffset}
                   </p>
                 </div>
 
@@ -321,7 +383,6 @@ function parsePosition(value: string | undefined): "earliest" | "latest" {
   return value === "earliest" ? "earliest" : "latest";
 }
 
-
 function buildBrowseHref(
   basePath: string,
   query: {
@@ -329,11 +390,11 @@ function buildBrowseHref(
     position?: "earliest" | "latest";
     offset?: number;
     limit: number;
-  }
+  },
 ) {
   const searchParams = new URLSearchParams({
     partition: String(query.partition),
-    limit: String(query.limit)
+    limit: String(query.limit),
   });
 
   if (typeof query.offset === "number") {

--- a/web/app/topics/page.tsx
+++ b/web/app/topics/page.tsx
@@ -1,6 +1,16 @@
-import { EmptyState, ErrorState, PageFrame, StatCard } from "@/components/page-frame";
+import {
+  EmptyState,
+  ErrorState,
+  PageFrame,
+  StatCard,
+} from "@/components/page-frame";
 import { TopicsTable } from "@/components/topics-table";
 import { getTopics } from "@/lib/api";
+import {
+  PAGE_FRAME_PROPS_DATA,
+  PAGE_FRAME_PROPS_FOR_ERROR_STATE,
+} from "../../constants/topic";
+import { getTopicStats } from "@/utils/topicsUtils";
 
 export const dynamic = "force-dynamic";
 
@@ -9,16 +19,12 @@ export default async function TopicsPage() {
     .then((topics) => ({ topics, error: null as string | null }))
     .catch((error: unknown) => ({
       topics: null,
-      error: error instanceof Error ? error.message : "Unknown error"
+      error: error instanceof Error ? error.message : "Unknown error",
     }));
 
-  if (result.error || !result.topics) {
+  if (result.error) {
     return (
-      <PageFrame
-        eyebrow="Primary View"
-        title="Topics"
-        description="The central inspection screen for topic metadata."
-      >
+      <PageFrame {...PAGE_FRAME_PROPS_FOR_ERROR_STATE}>
         <ErrorState
           title="Failed to load topics"
           copy={result.error ?? "Unknown error"}
@@ -28,40 +34,40 @@ export default async function TopicsPage() {
   }
 
   const topics = result.topics;
-  const partitionCount = topics.reduce((sum, topic) => sum + topic.partitions.length, 0);
 
-  return (
-    <PageFrame
-      eyebrow="Primary View"
-      title="Topics"
-      description="The central inspection screen for topic metadata. Open a topic to inspect leaders, replicas, and ISR placement."
-    >
-      <div className="grid gap-4 md:grid-cols-3">
-        <StatCard label="Topics" value={String(topics.length)} hint="Backed by GET /api/topics." />
-        <StatCard
-          label="Partitions"
-          value={String(partitionCount)}
-          hint="Aggregate partition count across the cluster."
-        />
-        <StatCard
-          label="Unique Leaders"
-          value={String(
-            new Set(
-              topics.flatMap((topic) => topic.partitions.map((partition) => partition.leader))
-            ).size
-          )}
-          hint="Distinct broker leaders represented in topic metadata."
-        />
-      </div>
-
-      {topics.length === 0 ? (
+  if (topics?.length === 0) {
+    return (
+      <PageFrame {...PAGE_FRAME_PROPS_DATA}>
         <EmptyState
           title="No topics returned"
           copy="Kafka responded but there are no topics visible to this connection."
         />
-      ) : (
-        <TopicsTable topics={topics} />
-      )}
+      </PageFrame>
+    );
+  }
+
+  const { totalTopics, totalPartitions, totalLeaders } = getTopicStats(topics);
+
+  return (
+    <PageFrame {...PAGE_FRAME_PROPS_DATA}>
+      <div className="grid gap-4 md:grid-cols-3">
+        <StatCard
+          label="Topics"
+          value={totalTopics}
+          hint="Backed by GET /api/topics."
+        />
+        <StatCard
+          label="Partitions"
+          value={totalPartitions}
+          hint="Aggregate partition count across the cluster."
+        />
+        <StatCard
+          label="Unique Leaders"
+          value={totalLeaders}
+          hint="Distinct broker leaders represented in topic metadata."
+        />
+      </div>
+      <TopicsTable topics={topics} />
     </PageFrame>
   );
 }

--- a/web/components/page-frame.tsx
+++ b/web/components/page-frame.tsx
@@ -1,32 +1,41 @@
-type StatCardProps = {
-  label: string;
-  value: string;
-  hint: string;
-};
+import {
+  EmptyStateProps,
+  ErrorStateProps,
+  PageFrameProps,
+  StatCardProps,
+} from "@/interfaces/timeFrame.interface";
 
 export function StatCard({ label, value, hint }: StatCardProps) {
   return (
     <div
-      className="rounded-[24px] border p-5"
+      className="rounded-3xl border p-5"
       style={{
         borderColor: "var(--surface-border)",
         background: "var(--surface-1)",
-        boxShadow: "var(--shadow-elevated)"
+        boxShadow: "var(--shadow-elevated)",
       }}
     >
-      <p className="text-[11px] font-semibold uppercase tracking-[0.24em]" style={{ color: "var(--text-muted)" }}>
+      <p
+        className="text-[11px] font-semibold uppercase tracking-[0.24em]"
+        style={{ color: "var(--text-muted)" }}
+      >
         {label}
       </p>
-      <p className="mt-3 text-3xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>{value}</p>
-      <p className="mt-2 text-sm leading-6" style={{ color: "var(--text-muted)" }}>{hint}</p>
+      <p
+        className="mt-3 text-3xl font-semibold tracking-tight"
+        style={{ color: "var(--text-primary)" }}
+      >
+        {value}
+      </p>
+      <p
+        className="mt-2 text-sm leading-6"
+        style={{ color: "var(--text-muted)" }}
+      >
+        {hint}
+      </p>
     </div>
   );
 }
-
-type EmptyStateProps = {
-  title: string;
-  copy: string;
-};
 
 export function EmptyState({ title, copy }: EmptyStateProps) {
   return (
@@ -34,19 +43,24 @@ export function EmptyState({ title, copy }: EmptyStateProps) {
       className="rounded-[28px] border border-dashed p-8"
       style={{
         borderColor: "var(--surface-border)",
-        background: "var(--surface-1)"
+        background: "var(--surface-1)",
       }}
     >
-      <h3 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>{title}</h3>
-      <p className="mt-3 text-sm leading-7" style={{ color: "var(--text-muted)" }}>{copy}</p>
+      <h3
+        className="text-lg font-semibold"
+        style={{ color: "var(--text-primary)" }}
+      >
+        {title}
+      </h3>
+      <p
+        className="mt-3 text-sm leading-7"
+        style={{ color: "var(--text-muted)" }}
+      >
+        {copy}
+      </p>
     </div>
   );
 }
-
-type ErrorStateProps = {
-  title: string;
-  copy: string;
-};
 
 export function ErrorState({ title, copy }: ErrorStateProps) {
   return (
@@ -57,18 +71,11 @@ export function ErrorState({ title, copy }: ErrorStateProps) {
   );
 }
 
-type PageFrameProps = {
-  eyebrow: string;
-  title: string;
-  description: string;
-  children: React.ReactNode;
-};
-
 export function PageFrame({
   eyebrow,
   title,
   description,
-  children
+  children,
 }: PageFrameProps) {
   return (
     <section className="space-y-6">
@@ -77,16 +84,25 @@ export function PageFrame({
         style={{
           borderColor: "var(--surface-border)",
           background: "var(--surface-1)",
-          boxShadow: "var(--shadow-elevated)"
+          boxShadow: "var(--shadow-elevated)",
         }}
       >
-        <p className="text-[11px] font-semibold uppercase tracking-[0.24em]" style={{ color: "var(--text-muted)" }}>
+        <p
+          className="text-[11px] font-semibold uppercase tracking-[0.24em]"
+          style={{ color: "var(--text-muted)" }}
+        >
           {eyebrow}
         </p>
-        <h1 className="mt-3 text-4xl font-semibold tracking-tight" style={{ color: "var(--text-primary)" }}>
+        <h1
+          className="mt-3 text-4xl font-semibold tracking-tight"
+          style={{ color: "var(--text-primary)" }}
+        >
           {title}
         </h1>
-        <p className="mt-4 max-w-3xl text-sm leading-7" style={{ color: "var(--text-muted)" }}>
+        <p
+          className="mt-4 max-w-3xl text-sm leading-7"
+          style={{ color: "var(--text-muted)" }}
+        >
           {description}
         </p>
       </div>

--- a/web/components/topics-table.tsx
+++ b/web/components/topics-table.tsx
@@ -7,7 +7,7 @@ import type { Topic } from "@/lib/types";
 import { EmptyState } from "@/components/page-frame";
 
 type TopicsTableProps = {
-  topics: Topic[];
+  readonly topics: Topic[] | null;
 };
 
 export function TopicsTable({ topics }: TopicsTableProps) {
@@ -16,15 +16,26 @@ export function TopicsTable({ topics }: TopicsTableProps) {
   const normalizedQuery = deferredQuery.trim().toLowerCase();
 
   const filteredTopics = normalizedQuery
-    ? topics.filter((topic) => topic.name.toLowerCase().includes(normalizedQuery))
+    ? topics?.filter((topic) =>
+        topic.name.toLowerCase().includes(normalizedQuery),
+      )
     : topics;
 
   return (
     <div className="space-y-4">
-      <div className="rounded-[24px] border p-4" style={{ borderColor: "var(--surface-border)", background: "var(--surface-1)" }}>
+      <div
+        className="rounded-3xl border p-4"
+        style={{
+          borderColor: "var(--surface-border)",
+          background: "var(--surface-1)",
+        }}
+      >
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <label className="block w-full md:max-w-md">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.24em]" style={{ color: "var(--text-muted)" }}>
+            <span
+              className="text-[11px] font-semibold uppercase tracking-[0.24em]"
+              style={{ color: "var(--text-muted)" }}
+            >
               Search Topics
             </span>
             <input
@@ -38,27 +49,42 @@ export function TopicsTable({ topics }: TopicsTableProps) {
                 background: "var(--surface-2)",
                 color: "var(--text-primary)",
                 caretColor: "var(--accent)",
-                boxShadow: "none"
+                boxShadow: "none",
               }}
             />
           </label>
-          <p className="text-xs uppercase tracking-[0.18em]" style={{ color: "var(--text-muted)" }}>
-            Showing {filteredTopics.length} of {topics.length}
+          <p
+            className="text-xs uppercase tracking-[0.18em]"
+            style={{ color: "var(--text-muted)" }}
+          >
+            Showing {filteredTopics?.length} of {topics?.length}
           </p>
         </div>
       </div>
 
-      {filteredTopics.length === 0 ? (
+      {filteredTopics?.length === 0 ? (
         <EmptyState
           title="No topics match this search"
           copy="Try a different topic name or clear the current filter."
         />
       ) : (
-        <div className="overflow-hidden rounded-[28px] border" style={{ borderColor: "var(--surface-border)", background: "var(--surface-1)" }}>
+        <div
+          className="overflow-hidden rounded-[28px] border"
+          style={{
+            borderColor: "var(--surface-border)",
+            background: "var(--surface-1)",
+          }}
+        >
           <div className="overflow-x-auto">
             <table className="min-w-full border-collapse">
               <thead>
-                <tr className="border-b text-left text-[11px] uppercase tracking-[0.24em]" style={{ borderColor: "var(--surface-border)", color: "var(--text-muted)" }}>
+                <tr
+                  className="border-b text-left text-[11px] uppercase tracking-[0.24em]"
+                  style={{
+                    borderColor: "var(--surface-border)",
+                    color: "var(--text-muted)",
+                  }}
+                >
                   <th className="px-5 py-4 font-semibold">Topic</th>
                   <th className="px-5 py-4 font-semibold">Partitions</th>
                   <th className="px-5 py-4 font-semibold">Leaders</th>
@@ -66,8 +92,16 @@ export function TopicsTable({ topics }: TopicsTableProps) {
                 </tr>
               </thead>
               <tbody>
-                {filteredTopics.map((topic) => (
-                  <tr key={topic.name} className="border-t text-sm" style={{ borderColor: "color-mix(in srgb, var(--surface-border) 50%, transparent)", color: "var(--text-secondary)" }}>
+                {filteredTopics?.map((topic) => (
+                  <tr
+                    key={topic.name}
+                    className="border-t text-sm"
+                    style={{
+                      borderColor:
+                        "color-mix(in srgb, var(--surface-border) 50%, transparent)",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
                     <td className="px-5 py-4">
                       <Link
                         href={`/topics/${encodeURIComponent(topic.name)}`}
@@ -77,14 +111,21 @@ export function TopicsTable({ topics }: TopicsTableProps) {
                         {topic.name}
                       </Link>
                     </td>
-                    <td className="px-5 py-4 font-mono">{topic.partitions.length}</td>
+                    <td className="px-5 py-4 font-mono">
+                      {topic.partitions.length}
+                    </td>
                     <td className="px-5 py-4 font-mono">
                       {Array.from(
-                        new Set(topic.partitions.map((partition) => partition.leader))
+                        new Set(
+                          topic.partitions.map((partition) => partition.leader),
+                        ),
                       ).join(", ")}
                     </td>
                     <td className="px-5 py-4 font-mono">
-                      {topic.partitions.reduce((sum, partition) => sum + partition.isr.length, 0)}
+                      {topic.partitions.reduce(
+                        (sum, partition) => sum + partition.isr.length,
+                        0,
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/web/constants/topic.ts
+++ b/web/constants/topic.ts
@@ -1,0 +1,12 @@
+export const PAGE_FRAME_PROPS_FOR_ERROR_STATE = {
+  eyebrow: "Primary View",
+  title: "Topics",
+  description: "The central inspection screen for topic metadata.",
+};
+
+export const PAGE_FRAME_PROPS_DATA = {
+  eyebrow: "Primary View",
+  title: "Topics",
+  description:
+    "The central inspection screen for topic metadata. Open a topic to inspect leaders, replicas, and ISR placement.",
+};

--- a/web/interfaces/timeFrame.interface.ts
+++ b/web/interfaces/timeFrame.interface.ts
@@ -1,0 +1,22 @@
+export interface PageFrameProps {
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly description: string;
+  readonly children: React.ReactNode;
+}
+
+export interface ErrorStateProps {
+  readonly title: string;
+  readonly copy: string;
+}
+
+export interface EmptyStateProps {
+  readonly title: string;
+  readonly copy: string;
+}
+
+export interface StatCardProps {
+  readonly label: string;
+  readonly value: string;
+  readonly hint: string;
+}

--- a/web/utils/topicsUtils.ts
+++ b/web/utils/topicsUtils.ts
@@ -1,0 +1,25 @@
+import { Topic } from "@/lib/types";
+
+export const getTopicStats = (topics: Topic[] | null = []) => {
+  if (!topics)
+    return {
+      totalTopics: "0",
+      totalPartitions: "0",
+      totalLeaders: "0",
+    };
+
+  const partitionCount = topics.reduce(
+    (sum, t) => sum + t.partitions.length,
+    0,
+  );
+
+  const uniqueLeaders = new Set(
+    topics.flatMap((t) => t.partitions.map((p) => p.leader)),
+  ).size;
+
+  return {
+    totalTopics: String(topics.length),
+    totalPartitions: String(partitionCount),
+    totalLeaders: String(uniqueLeaders),
+  };
+};


### PR DESCRIPTION
Folder Restructuring: Moved utils, constants, and interfaces from /app to the project root to follow Next.js conventions.

Logic Extraction: Moved Kafka metric calculations (Partition counts, Unique Leaders) into a dedicated utility function getTopicStats.

Clean Rendering: Implemented the "Guard Clause" pattern to handle Error, Empty, and Success states with early returns, reducing JSX nesting.

Prop Standardization: Used the spread operator (...) with constant configuration objects for PageFrame to ensure UI consistency.